### PR TITLE
Feat/trending2

### DIFF
--- a/src/main/java/com/example/plusproject/domain/trending/TrendAspect.java
+++ b/src/main/java/com/example/plusproject/domain/trending/TrendAspect.java
@@ -7,7 +7,6 @@ import java.time.format.DateTimeFormatter;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/plusproject/domain/trending/TrendAspect.java
+++ b/src/main/java/com/example/plusproject/domain/trending/TrendAspect.java
@@ -20,7 +20,7 @@ public class TrendAspect {
 
 	private final RedisTemplate<String, String> redisTemplate; // RedisTemplate을 사용하여 Redis와 통신
 
-	@AfterReturning("execution(* com.example.plusproject..AccommodationController.searchAccommodations(..))")
+	@AfterReturning("execution(* com.example.plusproject..AccommodationController.searchAccommodationsV1(..))")
 	public void searchLogging(JoinPoint joinPoint) {
 		Object[] args = joinPoint.getArgs();
 

--- a/src/main/java/com/example/plusproject/domain/trending/controller/TrendingController.java
+++ b/src/main/java/com/example/plusproject/domain/trending/controller/TrendingController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.plusproject.common.dto.ApiResponseDto;
 import com.example.plusproject.domain.trending.dto.TrendingResponseDto;
 import com.example.plusproject.domain.trending.service.TrendingService;
-import com.example.plusproject.domain.user.dto.AuthResponseDto;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/example/plusproject/domain/trending/service/TrendingService.java
+++ b/src/main/java/com/example/plusproject/domain/trending/service/TrendingService.java
@@ -9,11 +9,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
-import com.example.plusproject.common.exception.CustomException;
-import com.example.plusproject.common.exception.ErrorType;
 import com.example.plusproject.domain.trending.dto.TrendingResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -37,8 +34,6 @@ public class TrendingService {
 				keys.add(key);
 			}
 		}
-
-		// TODO: 12시간 단위의 순위 집계해두고 있으면 그걸 불러오기
 
 		// 키들을 합쳐서 unionKey 생성
 		Set<String> topWords = Collections.emptySet();;

--- a/src/main/java/com/example/plusproject/domain/trending/service/TrendingService.java
+++ b/src/main/java/com/example/plusproject/domain/trending/service/TrendingService.java
@@ -1,14 +1,19 @@
 package com.example.plusproject.domain.trending.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import com.example.plusproject.common.exception.CustomException;
+import com.example.plusproject.common.exception.ErrorType;
 import com.example.plusproject.domain.trending.dto.TrendingResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -20,14 +25,46 @@ public class TrendingService {
 	private final RedisTemplate<String, String> redisTemplate;
 
 	public List<TrendingResponseDto> getTrending() {
-		String key = "search:" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH:00"));
 
-		Set<String> keywords = redisTemplate.opsForZSet().reverseRange(key, 0, 9);
+		// 지난 12시간 키 수집
+		List<String> keys = new ArrayList<>();
+		for (int i = 1; i <= 12; i++) {
+			LocalDateTime dateTime = LocalDateTime.now().minusHours(i);
+			String key = "search:" + dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH:00"));
 
+			// Redis에 존재하는 키만 추가
+			if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+				keys.add(key);
+			}
+		}
+
+		// TODO: 12시간 단위의 순위 집계해두고 있으면 그걸 불러오기
+
+		// 키들을 합쳐서 unionKey 생성
+		Set<String> topWords = Collections.emptySet();;
+		if (keys.size() >= 2) {
+			String unionKey = "search:combined:"
+				+ LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH:00")); // 12시간 합친 데이터의 새 키
+
+			// 만들어둔 합계 순위 표가 없다면 생성
+			if (Boolean.FALSE.equals(redisTemplate.hasKey(unionKey))) {
+				redisTemplate.opsForZSet().unionAndStore(keys.get(0), keys.subList(1, keys.size()), unionKey); //((기준키, 나머지키, 새로운키)
+				redisTemplate.expire(unionKey, Duration.ofHours(1)); // 만료 시간 : 1시간
+			}
+
+			// 상위 10개 검색어 조회
+			topWords = redisTemplate.opsForZSet().reverseRange(unionKey, 0, 9);
+		}
+		else if (keys.size() == 1) {
+			topWords = redisTemplate.opsForZSet().reverseRange(keys.get(0), 0, 9);
+		}
+
+
+		// 응답용 DTO로 변환
 		List<TrendingResponseDto> trendingList = new ArrayList<>();
 		int rank = 1;
-		for (String keyword : keywords) {
-			trendingList.add(new TrendingResponseDto(rank++, keyword));
+		for (String word : topWords) {
+			trendingList.add(new TrendingResponseDto(rank++, word));
 		}
 
 		return trendingList;


### PR DESCRIPTION
[데이터 수집 AOP]
- 시간별로 나누어 검색어가 저장됩니다.

[인기 검색어 순위 응답 API]
- 현재 시간대 기점 12~1시간 전 데이터들을 합산하여 순위를 계산합니다.
- 12~1시간 전 시간대에 데이터가 하나도 없다면 그냥 빈 값을 반환합니다.
- 현재 시간대 기점으로 합산한 순위는 이론상 1시간 동안 같은 순위이며, 해당 시간대에 첫 조회시에 데이터를 만들어두고 이 값을 계속 조회합니다. (매번 순위를 합산하는 무거운 동작을 방지하기 위해 이 방법을 선택했습니다.)